### PR TITLE
Create initial Haskell basics/basics page

### DIFF
--- a/en/lessons/basics/basics.md
+++ b/en/lessons/basics/basics.md
@@ -30,16 +30,17 @@ Follow this tutorial by running `ghci`:
     GHCi, version {{ site.ghc.version }}: https://www.haskell.org/ghc/  :? for help
     ghci>
 
-To use `Text` in Haskell, type in:
+To use the `Text` type in this tutorial, type in:
 
-```haskell
+```console?lang=haskell&prompt=ghci>,ghci|
 ghci> :set -XOverloadedStrings
 ghci> import qualified Data.Text as T
+ghci> import qualified Data.Text.IO as T
 ```
 
 You can try out Haskell by typing in a few simple expressions:
 
-```haskell
+```console?lang=haskell&prompt=ghci>,ghci|
 ghci> 2 + 3
 5
 ghci> 2 + 3 == 5
@@ -48,7 +49,7 @@ ghci> T.length "The quick brown fox jumps over the lazy dog"
 43
 ```
 
-Perhaps you're able to figure out what some of these expressions mean.
+Perhaps you are able to figure out what some of these expressions mean.
 
 ## Basic Data Types
 
@@ -56,15 +57,15 @@ Perhaps you're able to figure out what some of these expressions mean.
 
 Haskell has a bounded integer type called `Int`:
 
-```haskell
-ghci> 255 :: Int
-255
+```console?lang=haskell&prompt=ghci>,ghci|
+ghci> 196883 :: Int
+196883
 ```
 __Note__: `::` specifies the type being used.
 
 Haskell also supports arbitrary precision integers with `Integer`:
 
-```haskell
+```console?lang=haskell&prompt=ghci>,ghci|
 ghci> 123456789101112131415
 123456789101112131415
 ```
@@ -76,7 +77,7 @@ Haskell supports `Double`, a double-precision floating-point number.
 At least one digit must come before the decimal point and Haskell supports
 scientific `e` notation.
 
-```haskell
+```console?lang=haskell&prompt=ghci>,ghci|
 ghci> 3.14
 3.14
 ghci> .14
@@ -92,7 +93,7 @@ ghci> 2.7e10
 
 Booleans in Haskell are represented with `True` and `False`:
 
-```haskell
+```console?lang=haskell&prompt=ghci>,ghci|
 ghci> True
 True
 ghci> False
@@ -101,24 +102,26 @@ False
 
 ### Text
 
-Haskell supports unicode text. Strings are wrapped in double quotes:
+Haskell supports Unicode text. Text is wrapped in double quotes,
+and can be printed with `T.putStrLn`:
 
-```haskell
-ghci> "Hello" :: T.Text
-"Hello"
-ghci> "jalapeño" :: T.Text
-"jalape\241o"
+```console?lang=haskell&prompt=ghci>,ghci|
+ghci> T.putStrLn "Hello"
+Hello
+ghci> T.putStrLn "jalapeño"
+jalapeño
 ```
 
 Special characters can be represented with numeric escapes or escape codes:
 
-```haskell
-ghci> "'hi\"" :: T.Text
-"'hi\""
-ghci> "\n" :: T.Text
-"\n"
-ghci> "\42" :: T.Text
-"*"
+```console?lang=haskell&prompt=ghci>,ghci|
+ghci> T.putStrLn "'hi\""
+'hi"
+ghci> T.putStrLn "dis\njointed"
+dis
+jointed
+ghci> T.putStrLn "\42"
+*
 ```
 
 You'll learn more about data types in [collections](../collections/) and
@@ -128,10 +131,11 @@ You'll learn more about data types in [collections](../collections/) and
 
 ### Arithmetic
 
-Haskell supports the basic operators `+`, `-`, `*`, and `/`.
-Note that `/` never returns an integer.
+Haskell supports the basic operators: `+`, `-`, `*`, `/`, `**` and `^`.
+Note that `/` and `**` never operate on integers,
+whereas `^` only accepts positive integer powers.
 
-```haskell
+```console?lang=haskell&prompt=ghci>,ghci|
 ghci> 2 + 2
 4
 ghci> 2 - 1
@@ -140,11 +144,17 @@ ghci> 2 * 5
 10
 ghci> 10 / 5
 2.0
+ghci> 2 ** (-0.5)
+0.7071067811865476
+ghci> 1.5 ^ 2
+2.25
+ghci> 5 ^ 2
+25
 ```
 
 For integer division and integer modulus, use `div` and `mod`:
 
-```haskell
+```console?lang=haskell&prompt=ghci>,ghci|
 ghci> -8 `div` 3
 -2
 ghci> 243 `mod` 5
@@ -156,9 +166,9 @@ ghci> 2 * (5 `div` 2) + (5 `mod` 2)
 ### Boolean
 
 Haskell provides the boolean operators `||`, `&&`, and `not` that operate on
-`Bool`:
+`Bool`. These operators do not evaluate the second term if possible.
 
-```haskell
+```console?lang=haskell&prompt=ghci>,ghci|
 ghci> False || False
 False
 ghci> True || False
@@ -178,10 +188,10 @@ True
 ### Comparison
 
 Haskell comes with comparison operators for ordering: `<=`, `>=`, `<`, and `>`.
-The operator `==` compares equality whilst `/=` compares inequality.
+Conversely, the operator `==` compares equality whilst `/=` compares inequality.
 Values compared must be of the same type.
 
-```haskell
+```console?lang=haskell&prompt=ghci>,ghci|
 ghci> 1 > 2
 False
 ghci> 2 < 2
@@ -199,7 +209,7 @@ True
 
 String concatenation uses the `<>` operator:
 
-```haskell
-ghci> "abra" <> "cadabra" :: T.Text
-"abracadabra"
+```console?lang=haskell&prompt=ghci>,ghci|
+ghci> T.putStrLn ("abra" <> "cadabra")
+abracadabra
 ```

--- a/en/lessons/basics/basics.md
+++ b/en/lessons/basics/basics.md
@@ -1,5 +1,5 @@
 ---
-version: 1.3.0
+version: 1.0.0
 title: Basics
 ---
 
@@ -9,269 +9,197 @@ Getting started, basic data types, and basic operations.
 
 ## Getting Started
 
-### Installing Elixir
+### Installing Haskell
 
-Installation instructions for each OS can be found on elixir-lang.org in the [Installing Elixir](http://elixir-lang.org/install.html) guide.
+The recommended installation instructions for each OS can be found at
+[ghcup](https://www.haskell.org/ghcup/).
 
-After Elixir is installed, you can easily find the installed version.
+You can check the version of the Haskell compiler installed by running
+`ghc --version`:
 
-    % elixir -v
-    Erlang/OTP {{ site.erlang.OTP }} [erts-{{ site.erlang.erts }}] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
-
-    Elixir {{ site.elixir.version }}
+    % ghc --version
+    The Glorious Glasgow Haskell Compilation System, version {{ site.ghc.version }}
 
 ### Trying Interactive Mode
 
-Elixir comes with IEx, an interactive shell, which allows us to evaluate Elixir expressions as we go.
+Your installation should come with `ghci`, an interactive shell that allows you
+to try out code in real time.
 
-To get started, let's run `iex`:
+Follow this tutorial by running `ghci`:
 
-    Erlang/OTP {{ site.erlang.OTP }} [erts-{{ site.erlang.erts }}] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
+    GHCi, version {{ site.ghc.version }}: https://www.haskell.org/ghc/  :? for help
+    ghci>
 
-    Interactive Elixir ({{ site.elixir.version }}) - press Ctrl+C to exit (type h() ENTER for help)
-    iex>
+To use `Text` in Haskell, type in:
 
-Note: On Windows PowerShell, you need to type `iex.bat`.
+```haskell
+ghci> :set -XOverloadedStrings
+ghci> import qualified Data.Text as T
+```
 
-Let's go ahead and give it a try now by typing in a few simple expressions:
+You can try out Haskell by typing in a few simple expressions:
 
-```elixir
-iex> 2+3
+```haskell
+ghci> 2 + 3
 5
-iex> 2+3 == 5
-true
-iex> String.length("The quick brown fox jumps over the lazy dog")
+ghci> 2 + 3 == 5
+True
+ghci> T.length "The quick brown fox jumps over the lazy dog"
 43
 ```
 
-Don't worry if you don't understand every expression yet, but we hope you get the idea.
+Perhaps you're able to figure out what some of these expressions mean.
 
 ## Basic Data Types
 
 ### Integers
 
-```elixir
-iex> 255
+Haskell has a bounded integer type called `Int`:
+
+```haskell
+ghci> 255 :: Int
 255
 ```
+Note: specify the type to use with `::`.
 
-Support for binary, octal, and hexadecimal numbers comes built in:
+Haskell also supports arbitrary precision integers with `Integer`:
 
-```elixir
-iex> 0b0110
-6
-iex> 0o644
-420
-iex> 0x1F
-31
+```haskell
+ghci> 123456789101112131415
+123456789101112131415
 ```
+Note: `ghci` automatically defaults to `Integer` here.
 
 ### Floats
 
-In Elixir, floating point numbers require a decimal after at least one digit; they have 64-bit double precision and support `e` for exponent values:
+Haskell supports `Double`, a double-precision floating-point number.
+At least one digit must come before the decimal point and Haskell supports
+scientific `e` notation.
 
-```elixir
-iex> 3.14
+```haskell
+ghci> 3.14
 3.14
-iex> .14
-** (SyntaxError) iex:2: syntax error before: '.'
-iex> 1.0e-10
-1.0e-10
+ghci> .14
+
+<interactive>:2:1: error: parse error on input ‘.’
+ghci> 5e-10
+5.0e-10
+ghci> 2.7e10
+2.7e10
 ```
 
 ### Booleans
 
-Elixir supports `true` and `false` as booleans; everything is truthy except for `false` and `nil`:
+Booleans in Haskell are represented with `True` and `False`:
 
-```elixir
-iex> true
-true
-iex> false
-false
+```haskell
+ghci> True
+True
+ghci> False
+False
 ```
 
-### Atoms
+### Text
 
-An atom is a constant whose name is its value.
-If you're familiar with Ruby, these are synonymous with Symbols:
+Haskell supports unicode text. Strings are wrapped in double quotes:
 
-```elixir
-iex> :foo
-:foo
-iex> :foo == :bar
-false
-```
-
-The booleans `true` and `false` are also the atoms `:true` and `:false`, respectively.
-
-```elixir
-iex> is_atom(true)
-true
-iex> is_boolean(:true)
-true
-iex> :true === true
-true
-```
-
-Names of modules in Elixir are also atoms. `MyApp.MyModule` is a valid atom, even if no such module has been declared yet.
-
-```elixir
-iex> is_atom(MyApp.MyModule)
-true
-```
-
-Atoms are also used to reference modules from Erlang libraries, including built in ones.
-
-```elixir
-iex> :crypto.strong_rand_bytes 3
-<<23, 104, 108>>
-```
-
-### Strings
-
-Strings in Elixir are UTF-8 encoded and are wrapped in double quotes:
-
-```elixir
-iex> "Hello"
+```haskell
+ghci> "Hello" :: T.Text
 "Hello"
-iex> "dziękuję"
-"dziękuję"
+ghci> "jalapeño" :: T.Text
+"jalape\241o"
 ```
 
-Strings support line breaks and escape sequences:
+Special characters can be represented with numeric escapes or escape codes:
 
-```elixir
-iex> "foo
-...> bar"
-"foo\nbar"
-iex> "foo\nbar"
-"foo\nbar"
+```haskell
+ghci> "'hi\"" :: T.Text
+"'hi\""
+ghci> "\n" :: T.Text
+"\n"
+ghci> "\42" :: T.Text
+"*"
 ```
 
-Elixir also includes more complex data types.
-We'll learn more about these when we learn about [collections](../collections/) and [functions](../functions/).
+You'll learn more about data types in [collections](../collections/) and
+[functions](../functions/).
 
 ## Basic Operations
 
 ### Arithmetic
 
-Elixir supports the basic operators `+`, `-`, `*`, and `/` as you would expect.
-It's important to remember that `/` will always return a float:
+Haskell supports the basic operators `+`, `-`, `*`, and `/`.
+Note that `/` never returns an integer.
 
-```elixir
-iex> 2 + 2
+```haskell
+ghci> 2 + 2
 4
-iex> 2 - 1
+ghci> 2 - 1
 1
-iex> 2 * 5
+ghci> 2 * 5
 10
-iex> 10 / 5
+ghci> 10 / 5
 2.0
 ```
 
-If you need integer division or the division remainder (i.e., modulo), Elixir comes with two helpful functions to achieve this:
+For integer division and integer modulus, use `div` and `mod`:
 
-```elixir
-iex> div(10, 5)
-2
-iex> rem(10, 3)
-1
+```haskell
+ghci> -8 `div` 3
+-2
+ghci> 243 `mod` 5
+3
+ghci> 2 * (5 `div` 2) + (5 `mod` 2)
+5
 ```
 
 ### Boolean
 
-Elixir provides the `||`, `&&`, and `!` boolean operators.
-These support any types:
+Haskell provides the boolean operators `||`, `&&`, and `not` that operate on
+`Bool`:
 
-```elixir
-iex> -20 || true
--20
-iex> false || 42
-42
+```haskell
+ghci> False || False
+False
+ghci> True || False
+True
 
-iex> 42 && true
-true
-iex> 42 && nil
-nil
+ghci> False && True
+False
+ghci> True && True
+True
 
-iex> !42
-false
-iex> !false
-true
+ghci> not True
+False
+ghci> not False
+True
 ```
-
-There are three additional operators whose first argument _must_ be a boolean (`true` or `false`):
-
-```elixir
-iex> true and 42
-42
-iex> false or true
-true
-iex> not false
-true
-iex> 42 and true
-** (ArgumentError) argument error: 42
-iex> not 42
-** (ArgumentError) argument error
-```
-
-Note: Elixir's `and` and `or` actually map to `andalso` and `orelse` in Erlang.
 
 ### Comparison
 
-Elixir comes with all the comparison operators we're used to: `==`, `!=`, `===`, `!==`, `<=`, `>=`, `<`, and `>`.
+Haskell comes with comparison operators for ordering: `<=`, `>=`, `<`, and `>`.
+The operator `==` compares equality whilst `/=` compares inequality.
+Values compared must be of the same type.
 
-```elixir
-iex> 1 > 2
-false
-iex> 1 != 2
-true
-iex> 2 == 2
-true
-iex> 2 <= 3
-true
-```
+```haskell
+ghci> 1 > 2
+False
+ghci> 2 < 2
+False
+ghci> 5 >= 5
+True
 
-For strict comparison of integers and floats, use `===`:
-
-```elixir
-iex> 2 == 2.0
-true
-iex> 2 === 2.0
-false
-```
-
-An important feature of Elixir is that any two types can be compared; this is particularly useful in sorting. We don't need to memorize the sort order, but it is important to be aware of it:
-
-```elixir
-number < atom < reference < function < port < pid < tuple < map < list < bitstring
-```
-
-This can lead to some interesting, yet valid comparisons you may not find in other languages:
-
-```elixir
-iex> :hello > 999
-true
-iex> {:hello, :world} > [1, 2, 3]
-false
-```
-
-### String Interpolation
-
-If you've used Ruby, string interpolation in Elixir will look familiar:
-
-```elixir
-iex> name = "Sean"
-iex> "Hello #{name}"
-"Hello Sean"
+ghci> True == True
+True
+ghci> False /= True
+True
 ```
 
 ### String Concatenation
 
 String concatenation uses the `<>` operator:
 
-```elixir
-iex> name = "Sean"
-iex> "Hello " <> name
-"Hello Sean"
+```haskell
+ghci> "abra" <> "cadabra" :: T.Text
+"abracadabra"
 ```

--- a/en/lessons/basics/basics.md
+++ b/en/lessons/basics/basics.md
@@ -60,7 +60,7 @@ Haskell has a bounded integer type called `Int`:
 ghci> 255 :: Int
 255
 ```
-Note: specify the type to use with `::`.
+__Note__: `::` specifies the type being used.
 
 Haskell also supports arbitrary precision integers with `Integer`:
 
@@ -68,7 +68,7 @@ Haskell also supports arbitrary precision integers with `Integer`:
 ghci> 123456789101112131415
 123456789101112131415
 ```
-Note: `ghci` automatically defaults to `Integer` here.
+__Note__: `ghci` automatically defaults to `Integer` here.
 
 ### Floats
 

--- a/en/lessons/basics/basics.md
+++ b/en/lessons/basics/basics.md
@@ -37,6 +37,8 @@ ghci> :set -XOverloadedStrings
 ghci> import qualified Data.Text as T
 ghci> import qualified Data.Text.IO as T
 ```
+__Note__: qualified imports are used here to prevent name conflicts.
+Imports also allow you to choose the module namespace.
 
 You can try out Haskell by typing in a few simple expressions:
 
@@ -103,7 +105,8 @@ False
 ### Text
 
 Haskell supports Unicode text. Text is wrapped in double quotes,
-and can be printed with `T.putStrLn`:
+and can be printed with the function `T.putStrLn` that you imported
+from `Data.Text.IO`:
 
 ```console?lang=haskell&prompt=ghci>,ghci|
 ghci> T.putStrLn "Hello"
@@ -188,8 +191,8 @@ True
 ### Comparison
 
 Haskell comes with comparison operators for ordering: `<=`, `>=`, `<`, and `>`.
-Conversely, the operator `==` compares equality whilst `/=` compares inequality.
-Values compared must be of the same type.
+Moreover, the operator `==` checks for equality whilst `/=` checks for inequality.
+Values compared using these operators must have the same type.
 
 ```console?lang=haskell&prompt=ghci>,ghci|
 ghci> 1 > 2

--- a/en/lessons/basics/basics.md
+++ b/en/lessons/basics/basics.md
@@ -16,20 +16,20 @@ The recommended installation instructions for each OS can be found at
 
 You can check the version of the Haskell compiler installed by running
 `ghc --version`:
-
-    % ghc --version
-    The Glorious Glasgow Haskell Compilation System, version {{ site.ghc.version }}
-
+```shell
+$ ghc --version
+The Glorious Glasgow Haskell Compilation System, version {{ site.ghc.version }}
+```
 ### Trying Interactive Mode
 
 Your installation should come with `ghci`, an interactive shell that allows you
 to try out code in real time.
 
 Follow this tutorial by running `ghci`:
-
-    GHCi, version {{ site.ghc.version }}: https://www.haskell.org/ghc/  :? for help
-    ghci>
-
+```console?lang=haskell&prompt=ghci>,ghci|
+GHCi, version {{ site.ghc.version }}: https://www.haskell.org/ghc/  :? for help
+ghci>
+```
 To use the `Text` type in this tutorial, type in:
 
 ```console?lang=haskell&prompt=ghci>,ghci|


### PR DESCRIPTION
This resolves #3. 

I have written a page that does the following: 
* Provide instructions for installing Haskell
* Introduce `ghci` and import the `Text` type
* Cover basic data types
* Cover basic operators