### PR TITLE
Fixing typo and missing translations

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -41,6 +41,6 @@
   homepage: https://jonathanlorimer.dev
   contributions:
     - lesson
- languages:
+  languages:
    - en
   lessons: ['collections']

--- a/fr/index.md
+++ b/fr/index.md
@@ -1,0 +1,8 @@
+---
+title: Haskell School
+layout: home
+version: 1.0.0
+---
+
+  [ru]: /ru/
+  [fr]: /fr/

--- a/ru/index.md
+++ b/ru/index.md
@@ -1,0 +1,8 @@
+---
+title: Haskell School
+layout: home
+version: 1.0.0
+---
+
+  [ru]: /ru/
+  [fr]: /fr/


### PR DESCRIPTION
Fixes a build error caused by the having locale files `_data/locale` without the corresponding translations by stubbing those translations.

Also fixes a build error caused by a small typo in `_data/contributors.yml` introduced in #1