### PR TITLE
Add development CI

### DIFF
--- a/.github/workflows/ development-test.yml
+++ b/.github/workflows/ development-test.yml
@@ -1,0 +1,16 @@
+name: Haskell School Deployment
+on:
+  pull_request:
+    branches:
+      - develop-ci-test
+  push:
+    branches:
+      - develop-ci-test
+jobs:
+  Build-With-Jekyll:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: helaili/jekyll-action@v2
+        with:
+          build_only: true

--- a/.github/workflows/ development.yml
+++ b/.github/workflows/ development.yml
@@ -2,10 +2,10 @@ name: Haskell School Deployment
 on:
   pull_request:
     branches:
-      - develop-ci-test
+      - development
   push:
     branches:
-      - develop-ci-test
+      - development
 jobs:
   Build-With-Jekyll:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a Github workflow that automatically builds the `development` branch on push or PR.

This uses the same [helaili/jekyll-action@v2 action](https://github.com/helaili/jekyll-action) that the automated deployment of the main branch currently uses,
but with the `build_only` input set to `true` to avoid actually publishing.