### PR TITLE
Provide guidance on code block and import style

### DIFF
--- a/style/code.md
+++ b/style/code.md
@@ -2,6 +2,16 @@
 
 * The default prompt is `ghci>`. Do not add the imported modules in scope.
 * Use _haskell_ code blocks for Haskell code
+* Use _console?lang=haskell&prompt=ghci>,ghci|_ code blocks for ghci examples
+* Explicitly mention the names of modules and language extensions
+used at the beginning of each tutorial
+* Ensure that name conflicts, even if unseen in the tutorial, do not occur.
+Import data types unqualified unless in cases of name conflict.
+For example, to import `Data.Vector`, write: 
+```haskell 
+import Data.Vector (Vector)
+import qualified Data.Vector as V
+```
 * For terminal commands, _shell_ code blocks must be used, and the prompt should be `$`
 * Keep examples simple when possible
 


### PR DESCRIPTION
This is a part of the solution to #8. 

* Introduce language for ghci code blocks
* Mandate explicit mention of modules and language extensions used
* Mandate absence of name conflict
* Mandate unqualified data type imports when possible