### PR TITLE
basics/containers: Remove mention of undefined behaviour for head/tail

### DIFF
--- a/en/lessons/basics/containers.md
+++ b/en/lessons/basics/containers.md
@@ -279,7 +279,7 @@ ghci> tail ["Orange", "Banana", "Apple"]
 Unfortunately these functions reveal an ugly part of the language's base
 library; they may raise an exception, even when given an argument with the
 appropriate type. The cause of these exceptions is that they do not cover the
-full domain of possible inputs, so there is room for undefined behaviour.
+full domain of possible inputs.
 
 ```haskell
 ghci> head []


### PR DESCRIPTION
Currently, basics/containers claims that `head` / `tail` leave "room for undefined behavior". [Undefined behavior](https://en.wikipedia.org/wiki/Undefined_behavior) is a technical term with a precise meaning (“result of .. a program ... is prescribed to be unpredictable”) and `head` / `tail` don't cause it ever. I think it's a very bad idea to muddle distinction between an exception (a notion of a well-defined error condition familiar from most "high-level" languages) and UB (infamously contained in C/C++ or below).