### PR TITLE
handle when there is an uncreated chapter

### DIFF
--- a/_plugins/haskell_school/generator.rb
+++ b/_plugins/haskell_school/generator.rb
@@ -80,7 +80,14 @@ module HaskellSchool
             if default_lang == lang
               version_severity = 'none'
             else
-              reference_version = site.config['tree'][default_lang][section][chapter_name]['version']
+              default_lang_chapter = site.config['tree'][default_lang][section][chapter_name]
+
+              reference_version =
+                if default_lang_chapter.nil?
+                  nil
+                else
+                  default_lang_chapter['version']
+                end
               version_severity = version_severity(reference_version, chapter['version'])
             end
             site.config['tree'][lang][section][chapter_name]['version_severity'] = version_severity


### PR DESCRIPTION
This fixes the issue that is currently plaguing #28 (and, I suspect, #29 as well)

---

If the file _data/contents.yml had reference to a chapter which does not
exist for the default languge, this code would error. Commenting out the
three which did not exist fixed the problem.

at time of writing, these were:
  - types
  - algebraic-data-types
  - lists-tuples
  - pattern-matching-control-flow

instead fo commenting those out though, I decided to make the code a
little more robust to handle this case.