### PR TITLE
Fix nixpkgs version in shell.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,7 @@ Icon
 # Directories potentially created on remote AFP share
 .AppleDB
 .AppleDesktop
-Network Trash Folder
+Network\ Trash\ Folder
 Temporary Items
 .apdisk
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.7.4'
+ruby '>= 2.7.3', '< 3.0'
 
 gem 'autoprefixer-rails'
 gem 'jekyll'

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,11 @@
-let pkgs = import (fetchTarball path) {};
-    path = https://github.com/NixOS/nixpkgs/archive/master.tar.gz;
+let
+  githubTarball = owner: repo: rev:
+    builtins.fetchTarball { url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; };
+
+  nixpkgsSrc = commit:
+    githubTarball "NixOS" "nixpkgs" commit;
+
+  pkgs = import (nixpkgsSrc "c708f2f92a5bd04b14f58c0d8ab9772d2bc41f96") { };
 in with pkgs;
   mkShell {
     LOCALE_ARCHIVE_2_27 = "${glibcLocales}/lib/locale/locale-archive";

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ let
   nixpkgsSrc = commit:
     githubTarball "NixOS" "nixpkgs" commit;
 
-  pkgs = import (nixpkgsSrc "c708f2f92a5bd04b14f58c0d8ab9772d2bc41f96") { };
+  pkgs = import (nixpkgsSrc "5fd4f796b4210d691b1f89e1f29043d635cd20e0") { };
 in with pkgs;
   mkShell {
     LOCALE_ARCHIVE_2_27 = "${glibcLocales}/lib/locale/locale-archive";


### PR DESCRIPTION
Jekyll installation was breaking on my machine because the version in `shell.nix` wasn't fixed.