### PR TITLE
Add 'git' to the nix shell environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -10,6 +10,7 @@ in with pkgs;
   mkShell {
     LOCALE_ARCHIVE_2_27 = "${glibcLocales}/lib/locale/locale-archive";
     buildInputs = [
+      git
       ruby
       nodejs
       bundler


### PR DESCRIPTION
Jekyll seems to require the 'git' executable
