### PR TITLE
update nixpkgs version to nixos 22.05

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,9 @@ let
   nixpkgsSrc = commit:
     githubTarball "NixOS" "nixpkgs" commit;
 
-  pkgs = import (nixpkgsSrc "5fd4f796b4210d691b1f89e1f29043d635cd20e0") { };
+  # NixOS 22.05 as of 2022-06-09
+  pkgs = import (nixpkgsSrc "4348fc64bffc9687572125889ec15a47f3a7edca") { };
+
 in with pkgs;
   mkShell {
     LOCALE_ARCHIVE_2_27 = "${glibcLocales}/lib/locale/locale-archive";


### PR DESCRIPTION
I'm not aware of anything specific that this changes, just the routine chore of bringing the environment up-to-date. I did test to verify that the dev jekyll server launches. Also added a comment with the version and date, otherwise you have to dig through the commit history or something to figure out what that hash is pointing to.