### PR TITLE
Reorder lessons so Monoid comes before Foldable

### DIFF
--- a/_data/contents.yml
+++ b/_data/contents.yml
@@ -15,7 +15,7 @@ typeclasses:
   - comparison
   - enumeration
   - string-representation
-  - iteration
   - monoids
+  - iteration
   - functors
   - numbers


### PR DESCRIPTION
We previously but `Foldable` before `Monoid`, and I'm realizing that this ordering was a mistake. The biggest problem is that the minimal definition for `Foldable` is `foldr | foldMap`, and `foldMap` is way easier to implement than `foldr`. If we have `Monoid` established first, then we can just write `foldMap`-based `Foldable` instances.

On a related subject: I intend to skip over `foldr`, `foldl'`, etc. entirely in the typeclasses part of Haskell School. I think these subjects, if they really need to be discussed, should be treated monomorphically within the context of a lesson on the `[]` data structure, because list folds are a seriously difficult topic that doesn't need to be further complicated upfront by generalizing beyond list. Though even there, I'd be happier to mostly lean on the module docs that are there now, which I think are pretty great. As usual, open to contrary opinions, but personally I don't use these functions at all in normal work and so it's pretty hard for me to get motivated to tackle them.